### PR TITLE
Fix the English descriptions of the questionnaire

### DIFF
--- a/template/HDP.md
+++ b/template/HDP.md
@@ -32,16 +32,16 @@ fields:
 :::spotlight-danger
 請注意，若欲順利進入 COSCUP 年會會場，以下旅遊史、追蹤措施、接觸史、是否群聚皆須為「否」，如有不實填報，須負民事、刑事及行政等相關法律責任；如您有任何項目為「是」，請您放棄填寫問卷，待狀況解除後再行填寫。
 
-Attention! In order to enter any COSCUP venue, you have to check "No" in the following questions of Travel history, Follow-up Measures, Contact history, and Cluster. If you do not respond honestly, you shall take all legal liabilities therefrom. Please give up filling this questionnaire if you can not honestly check "No" in the aforementioned items.
+All participants are required to answer the following questions about the travel history, the follow-up measures, the contact history, and the cluster history before entering the COSCUP venue. You shall bear all the legal liability if you do not respond honestly. The questionnaire will be terminated if you can not refute the questions.
 :::
 
 :::spotlight-part
 
-## 旅遊史｜Travel history
+## 旅遊史｜Travel History
 
 請問您過去 14 天內，是否有從國外任何地區入境而未完成 14 天居家檢疫，或曾經前往有群聚/確診者活動而經公告之國內地點？
 
-Do you escape from 14 days of home quarantine if entering Taiwan from any foreign countries, or have you been to any domestic places declared as indiscriminately subject?
+Are you currently undergoing a 14-day home quarantine due to entry from any foreign country/region? Have you been to any announced domestic areas where the confirmed infected patient stopped by?
 
 - [ ] 否｜No
 
@@ -52,7 +52,7 @@ Do you escape from 14 days of home quarantine if entering Taiwan from any foreig
 
 請問您是否因任何原因，正在進行 14 天居家隔離、居家檢疫、或自主健康管理中？
 
-Are you currently undergoing 14 days of home isolation, home quarantine, or self-health management ?
+Are you currently undergoing 14-day home isolation, home quarantine, or self-health management?
 
 - [ ] 否｜No
 
@@ -63,7 +63,7 @@ Are you currently undergoing 14 days of home isolation, home quarantine, or self
 
 請問您過去 14 天內是否有接觸從國外回台之人士？
 
-Have you had contact with people who entered Taiwan from foreign countries in the past 14 days ?
+Have you been in close contact with people who entered Taiwan from foreign countries/regions during the past 14 days?
 
 - [ ] 否｜No
 
@@ -74,7 +74,7 @@ Have you had contact with people who entered Taiwan from foreign countries in th
 
 請問您過去 14 天內身邊是否有其他 2 人（含）以上出現下列疑似感染症狀？發燒症狀(額溫≧37.5°C)、咳嗽、流鼻水、鼻塞、喉嚨痛、頭痛、呼吸急促、肌肉痠痛、疲倦、味覺或嗅覺喪失、腹瀉。
 
-Are there more than 2 people (including 2 people) around you having the following symptoms in the past 14 days? fever (forehead temperature over 37.5°C), cough, runny nose, stuffy nose, sore throat, muscle pain, headache, fatigue, diarrhea, shortness of breath, loss of sense of taste or smell.
+Are there 2 or more people around you having any of the following symptoms during the past 14 days: fever (forehead temperature higher than 37.5°C), cough, runny/stuffy nose, sore throat, headache, shortness of breath, muscle pain, malaise, loss of smell or taste, or diarrhea?
 
 - [ ] 否｜No
 
@@ -83,7 +83,7 @@ Are there more than 2 people (including 2 people) around you having the followin
 
 本人已閱讀過以上說明，且願意提供個人資料，同時聲明以上所有資訊（包含個人資料）均正確無誤，如有不實，本人了解須負民事、刑事及行政等相關法律責任，若因不實填寫導致疫情擴散或大會損失將負權責。
 
-I certify that I have read the information aboveand have consented to provide mypersonal data.I also certify that all above statements(including my personal dada) are correct. If there is any false statement, I understand that I shall take all legal liabilities therefrom, it will be responsible for the spread of the epidemic situation or the loss of the conference.
+I have read the information above and have consented to provide my personal information. I hereby confirm that all the above statements and personal information are accurate. I understand that I shall bear all the legal liability if there is any inaccurate statement or personal information. I also understand that I am responsible for the spread of the disease or the loss of the conference associated with such inaccurate statements or personal information.
 
 - [ ] 同意｜Agree
 

--- a/template/HDP.md
+++ b/template/HDP.md
@@ -59,7 +59,7 @@ Are you currently undergoing 14-day home isolation, home quarantine, or self-hea
 :::
 :::spotlight-part
 
-## 接觸史｜Contact history
+## 接觸史｜Contact History
 
 請問您過去 14 天內是否有接觸從國外回台之人士？
 
@@ -70,7 +70,7 @@ Have you been in close contact with people who entered Taiwan from foreign count
 :::
 :::spotlight-part
 
-## 是否群聚｜Cluster
+## 是否群聚｜Cluster History
 
 請問您過去 14 天內身邊是否有其他 2 人（含）以上出現下列疑似感染症狀？發燒症狀(額溫≧37.5°C)、咳嗽、流鼻水、鼻塞、喉嚨痛、頭痛、呼吸急促、肌肉痠痛、疲倦、味覺或嗅覺喪失、腹瀉。
 


### PR DESCRIPTION
We did not translate the descriptions text-by-text. TBH we partially rewrote them in English instead of directly translated them into English. Some minor differences in term usages may be found.

BTW we suggest removing the declaration after "[...] are accurate" since the following part is redundant.